### PR TITLE
Issue #11: Improve performance when importing large feed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer
 RUN a2enmod rewrite
+RUN pecl install pcov && docker-php-ext-enable pcov
 RUN mkdir -p /opt/podsumer/
 RUN mkdir -p /opt/podsumer/conf
-# COPY ./php-fpm.conf /usr/local/etc/php-fpm.d/zzz-podsumer.conf
 COPY ./apache.conf /etc/apache2/sites-available/000-default.conf
 COPY ./apache.conf /etc/apache2/sites-enabled/000-default.conf
 COPY ./conf/podsumer.conf /opt/podsumer/conf/podsumer.conf

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     },
     "scripts": {
         "test": "phpunit tests",
-        "coverage": "phpunit --coverage-filter src --coverage-clover=clover.xml tests"
+        "coverage": "XDEBUG_MODE=coverage phpunit --coverage-filter src --coverage-clover=clover.xml tests"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     },
     "scripts": {
         "test": "phpunit tests",
-        "coverage": "XDEBUG_MODE=coverage phpunit --coverage-filter src --coverage-clover=clover.xml tests"
+        "coverage": "phpunit --coverage-filter src --coverage-clover=clover.xml tests"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "minimum-stability": "dev",
     "require-dev": {
-        "phpunit/phpunit": "^10.0@dev"
+        "phpunit/phpunit": "^10.4"
     },
     "scripts": {
         "test": "phpunit tests",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e8c54e4e44006cf39f4be63dcbbc8c3",
+    "content-hash": "8448fb0d3d2148e7770b6bfdc8f9595f",
     "packages": [],
     "packages-dev": [
         {
@@ -249,12 +249,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "bef7494cf9ffa1337207b2eeff12d97b73c5a461"
+                "reference": "8cba024d7a7b66366bb7f7712123896ff5ada4ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bef7494cf9ffa1337207b2eeff12d97b73c5a461",
-                "reference": "bef7494cf9ffa1337207b2eeff12d97b73c5a461",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8cba024d7a7b66366bb7f7712123896ff5ada4ca",
+                "reference": "8cba024d7a7b66366bb7f7712123896ff5ada4ca",
                 "shasum": ""
             },
             "require": {
@@ -320,7 +320,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:48:58+00:00"
+            "time": "2023-11-05T08:42:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -389,12 +389,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "9c3c60e74ccbefa8dd73ca87cac82f1b92ab1eda"
+                "reference": "e3c978565adbdbfee871a91a67fdac13fcaf375f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/9c3c60e74ccbefa8dd73ca87cac82f1b92ab1eda",
-                "reference": "9c3c60e74ccbefa8dd73ca87cac82f1b92ab1eda",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/e3c978565adbdbfee871a91a67fdac13fcaf375f",
+                "reference": "e3c978565adbdbfee871a91a67fdac13fcaf375f",
                 "shasum": ""
             },
             "require": {
@@ -446,7 +446,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:53:17+00:00"
+            "time": "2023-11-05T08:38:04+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -454,12 +454,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "7c1b55bb4dc0ba76745069ef244365e30e78cc6c"
+                "reference": "58658024d21903540b329eda76f2dcf9268b50c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/7c1b55bb4dc0ba76745069ef244365e30e78cc6c",
-                "reference": "7c1b55bb4dc0ba76745069ef244365e30e78cc6c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/58658024d21903540b329eda76f2dcf9268b50c0",
+                "reference": "58658024d21903540b329eda76f2dcf9268b50c0",
                 "shasum": ""
             },
             "require": {
@@ -507,7 +507,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:53:26+00:00"
+            "time": "2023-11-05T08:38:13+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -515,12 +515,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1f92e24fbe1dbb40d5aebbc7e92717ac42a487bc"
+                "reference": "fa22346521f4b2f82c2a13ba1a28c9b757b4bba4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1f92e24fbe1dbb40d5aebbc7e92717ac42a487bc",
-                "reference": "1f92e24fbe1dbb40d5aebbc7e92717ac42a487bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/fa22346521f4b2f82c2a13ba1a28c9b757b4bba4",
+                "reference": "fa22346521f4b2f82c2a13ba1a28c9b757b4bba4",
                 "shasum": ""
             },
             "require": {
@@ -568,7 +568,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:53:35+00:00"
+            "time": "2023-11-05T08:38:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -576,12 +576,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d9b2a63fcb5d3e8b420575ca55f29441511b25be"
+                "reference": "c32ea680a29ac6ebcad346702302211353db9371"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d9b2a63fcb5d3e8b420575ca55f29441511b25be",
-                "reference": "d9b2a63fcb5d3e8b420575ca55f29441511b25be",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c32ea680a29ac6ebcad346702302211353db9371",
+                "reference": "c32ea680a29ac6ebcad346702302211353db9371",
                 "shasum": ""
             },
             "require": {
@@ -669,7 +669,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-02T13:07:11+00:00"
+            "time": "2023-11-05T08:41:53+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -677,12 +677,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "59c1269de7e2403c5aaa2f66ce2a558767e3a1ab"
+                "reference": "c0dd8d593de76efc5387b6f59fa81d1142ff7a02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/59c1269de7e2403c5aaa2f66ce2a558767e3a1ab",
-                "reference": "59c1269de7e2403c5aaa2f66ce2a558767e3a1ab",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c0dd8d593de76efc5387b6f59fa81d1142ff7a02",
+                "reference": "c0dd8d593de76efc5387b6f59fa81d1142ff7a02",
                 "shasum": ""
             },
             "require": {
@@ -727,7 +727,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:51:10+00:00"
+            "time": "2023-11-05T08:36:04+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -735,12 +735,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "0a1add35b99c6ba2cef19ce2bb4c5df81e5761f9"
+                "reference": "3db0c02903b84269b29fc01d2cdee12b466c0cd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/0a1add35b99c6ba2cef19ce2bb4c5df81e5761f9",
-                "reference": "0a1add35b99c6ba2cef19ce2bb4c5df81e5761f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/3db0c02903b84269b29fc01d2cdee12b466c0cd2",
+                "reference": "3db0c02903b84269b29fc01d2cdee12b466c0cd2",
                 "shasum": ""
             },
             "require": {
@@ -785,7 +785,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:51:21+00:00"
+            "time": "2023-11-05T08:36:15+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -793,12 +793,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "99df68f71a4b67d43e931ec8d0e964f079830342"
+                "reference": "976d605bc37509624206e4ca77ffe0657c374259"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/99df68f71a4b67d43e931ec8d0e964f079830342",
-                "reference": "99df68f71a4b67d43e931ec8d0e964f079830342",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/976d605bc37509624206e4ca77ffe0657c374259",
+                "reference": "976d605bc37509624206e4ca77ffe0657c374259",
                 "shasum": ""
             },
             "require": {
@@ -842,7 +842,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:51:31+00:00"
+            "time": "2023-11-05T08:36:25+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -850,12 +850,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "d7dbc9fb26095a090761384e0a50d02d0fc56432"
+                "reference": "fd2147c23c3fee83db219d6bf86632aed459cd20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/d7dbc9fb26095a090761384e0a50d02d0fc56432",
-                "reference": "d7dbc9fb26095a090761384e0a50d02d0fc56432",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fd2147c23c3fee83db219d6bf86632aed459cd20",
+                "reference": "fd2147c23c3fee83db219d6bf86632aed459cd20",
                 "shasum": ""
             },
             "require": {
@@ -920,7 +920,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:51:40+00:00"
+            "time": "2023-11-05T08:36:33+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -928,12 +928,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "9085fb32b4cb10fe309fedc402d15413d88d1f79"
+                "reference": "29d4265739e534dbc79dfeefae1a7534411f5094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/9085fb32b4cb10fe309fedc402d15413d88d1f79",
-                "reference": "9085fb32b4cb10fe309fedc402d15413d88d1f79",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/29d4265739e534dbc79dfeefae1a7534411f5094",
+                "reference": "29d4265739e534dbc79dfeefae1a7534411f5094",
                 "shasum": ""
             },
             "require": {
@@ -979,7 +979,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:51:51+00:00"
+            "time": "2023-11-05T08:36:43+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -987,12 +987,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "d77210d69b1117bf354d49abd928455205c18182"
+                "reference": "256b76eaa62da8669c29e3fd56cc7aaef20b3c6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/d77210d69b1117bf354d49abd928455205c18182",
-                "reference": "d77210d69b1117bf354d49abd928455205c18182",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/256b76eaa62da8669c29e3fd56cc7aaef20b3c6c",
+                "reference": "256b76eaa62da8669c29e3fd56cc7aaef20b3c6c",
                 "shasum": ""
             },
             "require": {
@@ -1047,7 +1047,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:52:00+00:00"
+            "time": "2023-11-05T08:36:52+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1055,12 +1055,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5ac04ebceb8b8e271066e28c046896aa251827b7"
+                "reference": "c44298b68abb6311674c0dc6e720c77022d7d1bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5ac04ebceb8b8e271066e28c046896aa251827b7",
-                "reference": "5ac04ebceb8b8e271066e28c046896aa251827b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/c44298b68abb6311674c0dc6e720c77022d7d1bf",
+                "reference": "c44298b68abb6311674c0dc6e720c77022d7d1bf",
                 "shasum": ""
             },
             "require": {
@@ -1112,7 +1112,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:52:09+00:00"
+            "time": "2023-11-05T08:37:02+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1120,12 +1120,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "4f3de4972cae5fe3ed37b1423d96514b4c34f964"
+                "reference": "f33ad9247fc3d4d3f03593aaddc8bd1cf3de49f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/4f3de4972cae5fe3ed37b1423d96514b4c34f964",
-                "reference": "4f3de4972cae5fe3ed37b1423d96514b4c34f964",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f33ad9247fc3d4d3f03593aaddc8bd1cf3de49f4",
+                "reference": "f33ad9247fc3d4d3f03593aaddc8bd1cf3de49f4",
                 "shasum": ""
             },
             "require": {
@@ -1191,7 +1191,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:52:18+00:00"
+            "time": "2023-11-05T08:37:10+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1199,12 +1199,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "30ee9ff166ee4e0f7e7a71b9e5c98c8f18de9363"
+                "reference": "590126ff4f0145161d22f8ff9c98c05f305b26b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/30ee9ff166ee4e0f7e7a71b9e5c98c8f18de9363",
-                "reference": "30ee9ff166ee4e0f7e7a71b9e5c98c8f18de9363",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/590126ff4f0145161d22f8ff9c98c05f305b26b0",
+                "reference": "590126ff4f0145161d22f8ff9c98c05f305b26b0",
                 "shasum": ""
             },
             "require": {
@@ -1254,7 +1254,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:52:27+00:00"
+            "time": "2023-11-05T08:37:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -1262,12 +1262,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "bbe4257ec5d4603cfde501987f6924cd36e0e719"
+                "reference": "f1f2f9b66dc50533707b4c8462ede7b7f59bfa34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/bbe4257ec5d4603cfde501987f6924cd36e0e719",
-                "reference": "bbe4257ec5d4603cfde501987f6924cd36e0e719",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/f1f2f9b66dc50533707b4c8462ede7b7f59bfa34",
+                "reference": "f1f2f9b66dc50533707b4c8462ede7b7f59bfa34",
                 "shasum": ""
             },
             "require": {
@@ -1313,7 +1313,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:52:37+00:00"
+            "time": "2023-11-05T08:37:29+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1321,12 +1321,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "a13428c65412f15ae04c6d78eff8e9ac40660a4b"
+                "reference": "9df4cc1587cb14fbe0b4ec80d67b959daa00cdb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/a13428c65412f15ae04c6d78eff8e9ac40660a4b",
-                "reference": "a13428c65412f15ae04c6d78eff8e9ac40660a4b",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/9df4cc1587cb14fbe0b4ec80d67b959daa00cdb7",
+                "reference": "9df4cc1587cb14fbe0b4ec80d67b959daa00cdb7",
                 "shasum": ""
             },
             "require": {
@@ -1372,7 +1372,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:52:47+00:00"
+            "time": "2023-11-05T08:37:38+00:00"
         },
         {
             "name": "sebastian/object-reflector",
@@ -1380,12 +1380,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "fad5e522529042cb5e6a7669370482f0eeb11182"
+                "reference": "739a9d56bc84a5fd028f566d08bd36bc712d848e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/fad5e522529042cb5e6a7669370482f0eeb11182",
-                "reference": "fad5e522529042cb5e6a7669370482f0eeb11182",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/739a9d56bc84a5fd028f566d08bd36bc712d848e",
+                "reference": "739a9d56bc84a5fd028f566d08bd36bc712d848e",
                 "shasum": ""
             },
             "require": {
@@ -1429,7 +1429,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:52:57+00:00"
+            "time": "2023-11-05T08:37:46+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1437,12 +1437,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "387e26b49ab3791c6708369d450b761ea47c3436"
+                "reference": "5831b46c3858c0afcc8b0135821e3a9d2dcb924e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/387e26b49ab3791c6708369d450b761ea47c3436",
-                "reference": "387e26b49ab3791c6708369d450b761ea47c3436",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5831b46c3858c0afcc8b0135821e3a9d2dcb924e",
+                "reference": "5831b46c3858c0afcc8b0135821e3a9d2dcb924e",
                 "shasum": ""
             },
             "require": {
@@ -1494,7 +1494,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:53:44+00:00"
+            "time": "2023-11-05T08:38:30+00:00"
         },
         {
             "name": "sebastian/type",
@@ -1502,12 +1502,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "365c5f89210d083e72692087a532a5711d3872e8"
+                "reference": "791d72a91e5547cba1f8d19cc6594150c11e7d1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/365c5f89210d083e72692087a532a5711d3872e8",
-                "reference": "365c5f89210d083e72692087a532a5711d3872e8",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/791d72a91e5547cba1f8d19cc6594150c11e7d1a",
+                "reference": "791d72a91e5547cba1f8d19cc6594150c11e7d1a",
                 "shasum": ""
             },
             "require": {
@@ -1552,7 +1552,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:53:55+00:00"
+            "time": "2023-11-05T08:38:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1560,12 +1560,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "b99f591026bbfe4dfc3db92c5b302e65b855f2a6"
+                "reference": "e24af053f2e9d14ce405de79befb044d23201c5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/b99f591026bbfe4dfc3db92c5b302e65b855f2a6",
-                "reference": "b99f591026bbfe4dfc3db92c5b302e65b855f2a6",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/e24af053f2e9d14ce405de79befb044d23201c5a",
+                "reference": "e24af053f2e9d14ce405de79befb044d23201c5a",
                 "shasum": ""
             },
             "require": {
@@ -1607,7 +1607,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T06:54:04+00:00"
+            "time": "2023-11-05T08:38:48+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1662,9 +1662,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "phpunit/phpunit": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/src/Brickner/Podsumer/State.php
+++ b/src/Brickner/Podsumer/State.php
@@ -54,11 +54,19 @@ class State
         $this->installTables();
     }
 
-    protected function query(string $sql, array $params = []): array
+    protected function query(string $sql, array $params = []): array|bool
     {
-        $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($params);
-        return $stmt->fetchAll();
+        try {
+
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute($params);
+
+            return $stmt->fetchAll();
+
+        } catch (Exception $e) {
+            $this->main->log($e->getMessage());
+            return false;
+        }
     }
 
     public function addFeed(Feed $feed)

--- a/tests/Brickner/Podsumer/StateTest.php
+++ b/tests/Brickner/Podsumer/StateTest.php
@@ -18,7 +18,16 @@ final class StateTest extends TestCase
     {
         $tmp_main = new Main($this->root, [], [], [], true);
         unlink($tmp_main->getStateFilePath());
-        $this->main = new Main($this->root, [], [], [], true);
+
+        $env = [
+            'REQUEST_SCHEME' => 'http',
+            'HTTP_HOST' => 'example.com',
+            'REQUEST_URI' => '/',
+            'REQUEST_METHOD' => 'GET',
+            'REMOTE_ADDR' => '127.0.0.1',
+        ];
+
+        $this->main = new Main($this->root, $env, [], [], true);
         $this->state = new State($this->main);
     }
 
@@ -102,6 +111,5 @@ final class StateTest extends TestCase
         $item = $this->state->getFeedItem(1);
         $this->state->deleteItemMedia($item['id']);
      }
-
 }
 

--- a/www/index.php
+++ b/www/index.php
@@ -129,6 +129,7 @@ function delete_feed(array $args)
     $feed_id = intval($args['feed_id']);
     $main->getState()->deleteFeed($feed_id);
     header("Location: /");
+    die();
 }
 
 #[Route('/delete_audio', 'GET')]
@@ -140,6 +141,7 @@ function delete_audio(array $args)
     $main->getState()->deleteItemMedia($item_id);
     $item = $main->getState()->getFeedItem($item_id);
     header("Location: /feed?id=" . $item['feed_id']);
+    die();
 }
 
 #[Route('/rss', 'GET')]
@@ -284,7 +286,7 @@ function refresh(array $args)
     doRefresh(intval($args['feed_id']));
 
     header("Location: /feed?id=" . intval($args['feed_id']));
-    return;
+    die();
 }
 
 function doRefresh(int $feed_id) {


### PR DESCRIPTION
Re: #11

Current versions import a custom image for every item in a feed. Some feeds (e.g. The Daily) have 1k+ items and a good number of them have a custom image URL on them. This resulted in an HTTP request for each of those one thousand images which is _slow_. This change makes it so

Secondarily, I am piggy-backing a change to how SQL errors are handled. They are now output to the log, and the query method returns false. Lastly, `die()` calls were added to the controller after the heade redirects to cutoff any additional output.