### PR TITLE
Fix OPML export

### DIFF
--- a/templates/opml.xml.php
+++ b/templates/opml.xml.php
@@ -1,11 +1,11 @@
-<?= '<?xml version="1.0" encoding="UTF-8"?>' ?>
-<opml version="1.0">
+<?= '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL ?>
+<opml version="1.1">
     <head>
         <title>Podsumer Feeds</title>
     </head>
     <body>
         <? foreach ($feeds as $feed): ?>
-        <outline title="<?= htmlspecialchars($feed['name']) ?>"  text="<?= htmlspecialchars($feed['name']) ?>" xmlUrl="<?= $host ?>/rss?feed_id=<?= $feed['id'];?>"  htmlUrl="<?= $host ?>/feed?id=<?= $feed['id'];?>" type="rss" />
+        <outline text="<?= htmlspecialchars($feed['name']) ?>" title="<?= htmlspecialchars($feed['name']) ?>" xmlUrl="<?= $host ?>/rss?feed_id=<?= $feed['id']; ?>" htmlUrl="<?= $host ?>/feed?id=<?= $feed['id']; ?>" type="rss"></outline>
         <? endforeach ?>
     </body>
 </opml>

--- a/www/index.php
+++ b/www/index.php
@@ -189,7 +189,7 @@ function opml(array $args)
     ];
 
     header("Content-disposition: attachment; filename=\"podsumer.opml\"");
-    header("Content-Type: text/x-opml");
+    header("Content-Type: text/x-opml; charset=UTF-8");
 
     Template::renderXml($main, 'opml', $vars);
 }


### PR DESCRIPTION
## Summary
- revert short-tag changes
- ensure OPML output uses standard 1.1 format with closing outline tags
- specify charset in the OPML response header

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure` *(fails: SSL peer certificate or SSH remote key was not OK)*

------
https://chatgpt.com/codex/tasks/task_e_684ca6fb62088322bf260e6f4647c715