### PR TITLE
Fix RSS format for podcast apps

### DIFF
--- a/templates/rss.xml.php
+++ b/templates/rss.xml.php
@@ -15,9 +15,9 @@
       <title><?= $item['name'] ?></title>
       <description><![CDATA[ <?= $item['description'] ?> ]]></description>
       <pubDate><?= $item['published'] ?></pubDate>
-      <enclosure url="<?= $host ?>/audio?item_id=<?= $item['id'] ?>" type="audio/mp3" length="<?= $item['size'] ?>"/>
+      <enclosure url="<?= $host ?>/audio?item_id=<?= $item['id'] ?>" type="audio/mpeg" length="<?= $item['size'] ?>"/>
       <link><?= $host ?>/item?item_id=<?= $item['id'] ?></link>
-      <guid><?= $host ?>/item?item_id=<?= $item['id'] ?></guid>
+      <guid isPermaLink="false"><?= $item['guid'] ?? ($host . '/item?item_id=' . $item['id']) ?></guid>
       <itunes:image href="<?= $host ?>/image?item_id=<?= $item['id'] ?>" />
     </item>
     <? endforeach ?>

--- a/www/index.php
+++ b/www/index.php
@@ -162,6 +162,12 @@ function rss(array $args)
     $items = $main->getState()->getFeedItems($feed_id);
     $feed = $main->getState()->getFeed($feed_id);
 
+    foreach ($items as &$i) {
+        $i['published'] = date(DATE_RSS, strtotime($i['published']));
+    }
+
+    $feed['last_update'] = date(DATE_RSS, strtotime($feed['last_update']));
+
     $vars = [
         'items' => $items,
         'feed' => $feed,


### PR DESCRIPTION
## Summary
- ensure RFC-822 dates are used in RSS output
- set correct enclosure MIME type and add GUID attributes

## Testing
- `composer test` *(fails: SSL certificate problem)*

------
https://chatgpt.com/codex/tasks/task_e_684ce6bcb25c83229940c4beb046e925