### PR TITLE
Fix RSS format for podcast apps

### DIFF
--- a/templates/rss.xml.php
+++ b/templates/rss.xml.php
@@ -4,6 +4,8 @@
     <title><?= $feed['name'] ?></title>
     <description><?=  $feed['description'] ?></description>
     <itunes:image href="<?= $host ?>/image?feed_id=<?= $feed['id'] ?>" />
+    <itunes:summary><![CDATA[ <?= substr(strip_tags($feed['description']), 0, 4000) ?> ]]></itunes:summary>
+    <itunes:explicit>false</itunes:explicit>
     <language>en-us</language>
     <generator>podsumer</generator>
     <lastBuildDate><?= $feed['last_update'] ?></lastBuildDate>
@@ -13,11 +15,14 @@
     <? foreach($items as $item): ?>
     <item>
       <title><?= $item['name'] ?></title>
+      <itunes:title><?= $item['name'] ?></itunes:title>
       <description><![CDATA[ <?= $item['description'] ?> ]]></description>
+      <itunes:summary><![CDATA[ <?= substr(strip_tags($item['description']), 0, 4000) ?> ]]></itunes:summary>
+      <itunes:explicit>false</itunes:explicit>
       <pubDate><?= $item['published'] ?></pubDate>
-      <enclosure url="<?= $host ?>/audio?item_id=<?= $item['id'] ?>" type="audio/mp3" length="<?= $item['size'] ?>"/>
+      <enclosure url="<?= $host ?>/audio?item_id=<?= $item['id'] ?>" type="audio/mpeg" length="<?= $item['size'] ?>"/>
       <link><?= $host ?>/item?item_id=<?= $item['id'] ?></link>
-      <guid><?= $host ?>/item?item_id=<?= $item['id'] ?></guid>
+      <guid isPermaLink="false"><?= $item['guid'] ?? ($host . '/item?item_id=' . $item['id']) ?></guid>
       <itunes:image href="<?= $host ?>/image?item_id=<?= $item['id'] ?>" />
     </item>
     <? endforeach ?>

--- a/www/index.php
+++ b/www/index.php
@@ -162,6 +162,12 @@ function rss(array $args)
     $items = $main->getState()->getFeedItems($feed_id);
     $feed = $main->getState()->getFeed($feed_id);
 
+    foreach ($items as &$i) {
+        $i['published'] = date(DATE_RSS, strtotime($i['published']));
+    }
+
+    $feed['last_update'] = date(DATE_RSS, strtotime($feed['last_update']));
+
     $vars = [
         'items' => $items,
         'feed' => $feed,


### PR DESCRIPTION
## Summary
- ensure RFC-822 dates are used in RSS output
- set correct enclosure MIME type and add GUID attributes
- add iTunes summary and explicit tags for better RSS validation

## Testing
- `composer test` *(fails: SSL peer certificate or DNS issues)*

------
https://chatgpt.com/codex/tasks/task_e_684ce6bcb25c83229940c4beb046e925