### PR TITLE
Add sponsorblock client integration

### DIFF
--- a/src/Brickner/Podsumer/State.php
+++ b/src/Brickner/Podsumer/State.php
@@ -13,7 +13,7 @@ class State
 {
     use TStateSchemaMigrations;
 
-    CONST VERSION = 2; # The version of the schema for this commit.
+    CONST VERSION = 3; # The version of the schema for this commit.
 
     protected Main $main;
     protected $state_file_path;
@@ -190,13 +190,13 @@ class State
 
     public function getFeedItem(int $item_id): array
     {
-        $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position FROM items JOIN feeds ON feeds.id = items.feed_id WHERE items.id = :id ORDER BY items.published DESC';
+        $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position, items.sponsorblock FROM items JOIN feeds ON feeds.id = items.feed_id WHERE items.id = :id ORDER BY items.published DESC';
         return $this->query($sql, ['id' => $item_id])[0];
     }
 
     public function getFeedItems(int $feed_id): array
     {
-        $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position FROM items JOIN feeds ON feeds.id = items.feed_id WHERE items.feed_id = :id ORDER BY items.published DESC';
+        $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position, items.sponsorblock FROM items JOIN feeds ON feeds.id = items.feed_id WHERE items.feed_id = :id ORDER BY items.published DESC';
         $result = $this->query($sql, ['id' => $feed_id]);
 
         // The query helper returns false when an exception is caught. Convert that
@@ -365,6 +365,24 @@ class State
         }
 
         return intval($result[0]['playback_position']);
+    }
+
+    public function setSponsorblock(int $item_id, string $data): void
+    {
+        $sql = 'UPDATE items SET sponsorblock = :data WHERE id = :id';
+        $this->query($sql, ['id' => $item_id, 'data' => $data]);
+    }
+
+    public function getSponsorblock(int $item_id): ?string
+    {
+        $sql = 'SELECT sponsorblock FROM items WHERE id = :id';
+        $result = $this->query($sql, ['id' => $item_id]);
+
+        if (false === $result || empty($result) || !isset($result[0]['sponsorblock'])) {
+            return null;
+        }
+
+        return strval($result[0]['sponsorblock']);
     }
 
     protected function loadFile(string $filename): string

--- a/src/Brickner/Podsumer/TStateSchemaMigrations.php
+++ b/src/Brickner/Podsumer/TStateSchemaMigrations.php
@@ -11,7 +11,8 @@ trait TStateSchemaMigrations
     private array $versions = [ # ORDER IS IMPORTANT
         'create',
         'addDiskStorage',
-        'addPlaybackPosition'
+        'addPlaybackPosition',
+        'addSponsorblock'
     ];
 
     protected function checkDBVersion()
@@ -55,6 +56,12 @@ trait TStateSchemaMigrations
 
         $addPlayback = $this->query("ALTER TABLE `items` ADD COLUMN playback_position INTEGER DEFAULT 0");
         return $addPlayback !== false;
+    }
+
+    public function addSponsorblock(): bool {
+
+        $addSB = $this->query("ALTER TABLE `items` ADD COLUMN sponsorblock TEXT");
+        return $addSB !== false;
     }
 }
 

--- a/templates/item.html.php
+++ b/templates/item.html.php
@@ -71,6 +71,53 @@
         const itemId = <?= $item['id'] ?>;
         const interval = (<?= $this->main->getConf('podsumer', 'playback_interval') ?? 5 ?>) * 1000;
         const rewind = <?= $this->main->getConf('podsumer', 'playback_rewind') ?? 5 ?>;
+        const guid = <?= json_encode($item['guid']) ?>;
+        let sbSegments = [];
+        let sbReady = false;
+        let playQueued = false;
+
+        function loadSponsorblock() {
+            fetch('/get_sponsorblock?item_id=' + itemId)
+                .then(r => r.json())
+                .then(d => {
+                    sbSegments = d.segments || [];
+                    if (sbSegments.length === 0) {
+                        const api = 'https://sponsor.ajay.app/api/skipSegments?service=podcast&url=' + encodeURIComponent(guid);
+                        return fetch(api)
+                            .then(r => r.json())
+                            .then(s => {
+                                sbSegments = Array.isArray(s) ? s : [];
+                                const params = new URLSearchParams();
+                                params.append('item_id', itemId);
+                                params.append('segments', JSON.stringify(sbSegments));
+                                fetch('/set_sponsorblock', {method: 'POST', body: params});
+                            });
+                    }
+                })
+                .finally(() => {
+                    sbReady = true;
+                    if (playQueued) { audio.play(); }
+                });
+        }
+
+        audio.addEventListener('play', () => {
+            if (!sbReady) {
+                playQueued = true;
+                audio.pause();
+                loadSponsorblock();
+            }
+        });
+
+        audio.addEventListener('timeupdate', () => {
+            if (!sbReady) return;
+            const ct = audio.currentTime;
+            for (const seg of sbSegments) {
+                if (ct >= seg.start && ct < seg.end) {
+                    audio.currentTime = seg.end;
+                    break;
+                }
+            }
+        });
 
         fetch('/get_playback?item_id=' + itemId)
             .then(r => r.json())

--- a/tests/Brickner/Podsumer/StateTest.php
+++ b/tests/Brickner/Podsumer/StateTest.php
@@ -117,5 +117,18 @@ final class StateTest extends TestCase
         // Assert it is greater than 0
         $this->assertGreaterThan(0, $this->state->getVersion());
     }
+
+    public function testSponsorblock()
+    {
+        $this->feed = new Feed(self::TEST_FEED_URL);
+        $this->state->addFeed($this->feed);
+        $item = $this->state->getFeedItem(1);
+
+        $json = '[{"start":0,"end":1}]';
+        $this->state->setSponsorblock($item['id'], $json);
+        $ret = $this->state->getSponsorblock($item['id']);
+
+        $this->assertEquals($json, $ret);
+    }
 }
 

--- a/www/index.php
+++ b/www/index.php
@@ -451,3 +451,36 @@ function set_playback(array $args): void
     $main->getState()->setPlaybackPosition(intval($args['item_id']), intval($args['position']));
 }
 
+#[Route('/get_sponsorblock', 'GET', true)]
+function get_sponsorblock(array $args): void
+{
+    global $main;
+
+    if (empty($args['item_id'])) {
+        $main->setResponseCode(404);
+        return;
+    }
+
+    $data = $main->getState()->getSponsorblock(intval($args['item_id']));
+    $segments = [];
+    if (!empty($data)) {
+        $segments = json_decode($data, true, 512, JSON_OBJECT_AS_ARRAY) ?? [];
+    }
+
+    header('Content-Type: application/json');
+    echo json_encode(['segments' => $segments]);
+}
+
+#[Route('/set_sponsorblock', 'POST', true)]
+function set_sponsorblock(array $args): void
+{
+    global $main;
+
+    if (empty($args['item_id']) || !isset($args['segments'])) {
+        $main->setResponseCode(404);
+        return;
+    }
+
+    $main->getState()->setSponsorblock(intval($args['item_id']), strval($args['segments']));
+}
+


### PR DESCRIPTION
## Summary
- add new DB migration for item sponsorblock data
- expose sponsorblock API routes
- support saving sponsorblock segments on the server
- fetch sponsorblock info and auto skip in the player
- test sponsorblock support

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6850a265b3d0832299378655596f714c