### PR TITLE
Add sponsorblock support

### DIFF
--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -37,7 +37,8 @@ CREATE TABLE IF NOT EXISTS `items` (
     size INTEGER NOT NULL,
     audio_url TEXT NOT NULL,
     audio_file INTEGER NULL,
-    image INTEGER NULL
+    image INTEGER NULL,
+    sponsorblock TEXT
 );
 
 CREATE TABLE IF NOT EXISTS `versions` (

--- a/src/Brickner/Podsumer/State.php
+++ b/src/Brickner/Podsumer/State.php
@@ -13,7 +13,7 @@ class State
 {
     use TStateSchemaMigrations;
 
-    CONST VERSION = 2; # The version of the schema for this commit.
+    CONST VERSION = 3; # The version of the schema for this commit.
 
     protected Main $main;
     protected $state_file_path;
@@ -365,6 +365,24 @@ class State
         }
 
         return intval($result[0]['playback_position']);
+    }
+
+    public function setSponsorBlock(int $item_id, string $data): void
+    {
+        $sql = 'UPDATE items SET sponsorblock = :data WHERE id = :id';
+        $this->query($sql, ['id' => $item_id, 'data' => $data]);
+    }
+
+    public function getSponsorBlock(int $item_id): ?string
+    {
+        $sql = 'SELECT sponsorblock FROM items WHERE id = :id';
+        $result = $this->query($sql, ['id' => $item_id]);
+
+        if (false === $result || empty($result) || empty($result[0]['sponsorblock'])) {
+            return null;
+        }
+
+        return strval($result[0]['sponsorblock']);
     }
 
     protected function loadFile(string $filename): string

--- a/src/Brickner/Podsumer/TStateSchemaMigrations.php
+++ b/src/Brickner/Podsumer/TStateSchemaMigrations.php
@@ -11,7 +11,8 @@ trait TStateSchemaMigrations
     private array $versions = [ # ORDER IS IMPORTANT
         'create',
         'addDiskStorage',
-        'addPlaybackPosition'
+        'addPlaybackPosition',
+        'addSponsorBlock'
     ];
 
     protected function checkDBVersion()
@@ -55,6 +56,17 @@ trait TStateSchemaMigrations
 
         $addPlayback = $this->query("ALTER TABLE `items` ADD COLUMN playback_position INTEGER DEFAULT 0");
         return $addPlayback !== false;
+    }
+
+    public function addSponsorBlock(): bool {
+        $cols = $this->query("PRAGMA table_info(items)");
+        foreach ($cols as $col) {
+            if (($col['name'] ?? '') === 'sponsorblock') {
+                return true;
+            }
+        }
+        $addSb = $this->query("ALTER TABLE `items` ADD COLUMN sponsorblock TEXT");
+        return $addSb !== false;
     }
 }
 

--- a/templates/item.html.php
+++ b/templates/item.html.php
@@ -81,26 +81,30 @@
             return Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2,'0')).join('').substring(0, 6);
         }
 
+        async function checkSponsorblock() {
+            const r = await fetch('/get_sponsorblock?item_id=' + itemId);
+            if (r.ok) {
+                const data = await r.json();
+                sbSegments = (data[0]?.segments || []).map(s => s.segment);
+                sbReady = true;
+            } else if (r.status === 204) {
+                sbReady = false;
+            }
+        }
+
         async function fetchSponsorblock() {
             try {
-                const r = await fetch('/get_sponsorblock?item_id=' + itemId);
+                const prefix = await computeHashPrefix();
+                const categories = encodeURIComponent(JSON.stringify(['sponsor']));
+                const api = 'https://sponsor.ajay.app/api/skipSegments/' + prefix +
+                    '?categories=' + categories + '&service=podcast';
+                const data = await fetch(api).then(x => x.json());
+                sbSegments = (data[0]?.segments || []).map(s => s.segment);
 
-                if (r.status === 204) {
-                    const prefix = await computeHashPrefix();
-                    const categories = encodeURIComponent(JSON.stringify(['sponsor']));
-                    const api = 'https://sponsor.ajay.app/api/skipSegments/' + prefix +
-                        '?categories=' + categories + '&service=podcast';
-                    const data = await fetch(api).then(x => x.json());
-                    sbSegments = (data[0]?.segments || []).map(s => s.segment);
-
-                    const params = new URLSearchParams();
-                    params.append('item_id', itemId);
-                    params.append('data', JSON.stringify(data));
-                    fetch('/set_sponsorblock', {method: 'POST', body: params});
-                } else if (r.ok) {
-                    const data = await r.json();
-                    sbSegments = (data[0]?.segments || []).map(s => s.segment);
-                }
+                const params = new URLSearchParams();
+                params.append('item_id', itemId);
+                params.append('data', JSON.stringify(data));
+                fetch('/set_sponsorblock', {method: 'POST', body: params});
             } finally {
                 sbReady = true;
             }
@@ -118,6 +122,9 @@
         }
 
         audio.addEventListener('timeupdate', skipIfNeeded);
+
+        // check for cached sponsorblock data when page loads
+        checkSponsorblock();
 
         audio.addEventListener('play', async () => {
             if (!sbReady) {

--- a/templates/item.html.php
+++ b/templates/item.html.php
@@ -8,7 +8,7 @@
 
     <div class="media-container">
         <img src="/image?<?= 'item_id='.$item['id'] ?: 'feed_id'.$feed['id'] ?>" class="album-art">
-        <audio autoplay controls src="/audio?item_id=<?= $item['id'] ?>" class="player"></audio>
+        <audio controls src="/audio?item_id=<?= $item['id'] ?>" class="player"></audio>
     </div>
 
     <div id="item-desc">
@@ -71,6 +71,61 @@
         const itemId = <?= $item['id'] ?>;
         const interval = (<?= $this->main->getConf('podsumer', 'playback_interval') ?? 5 ?>) * 1000;
         const rewind = <?= $this->main->getConf('podsumer', 'playback_rewind') ?? 5 ?>;
+        let sbSegments = null;
+        let sbReady = false;
+
+        async function computeHashPrefix() {
+            const resp = await fetch('/audio?item_id=' + itemId, {headers: {Range: 'bytes=0-131071'}});
+            const buf = await resp.arrayBuffer();
+            const hash = await crypto.subtle.digest('SHA-256', buf);
+            return Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2,'0')).join('').substring(0, 6);
+        }
+
+        async function fetchSponsorblock() {
+            try {
+                const r = await fetch('/get_sponsorblock?item_id=' + itemId);
+
+                if (r.status === 204) {
+                    const prefix = await computeHashPrefix();
+                    const categories = encodeURIComponent(JSON.stringify(['sponsor']));
+                    const api = 'https://sponsor.ajay.app/api/skipSegments/' + prefix +
+                        '?categories=' + categories + '&service=podcast';
+                    const data = await fetch(api).then(x => x.json());
+                    sbSegments = (data[0]?.segments || []).map(s => s.segment);
+
+                    const params = new URLSearchParams();
+                    params.append('item_id', itemId);
+                    params.append('data', JSON.stringify(data));
+                    fetch('/set_sponsorblock', {method: 'POST', body: params});
+                } else if (r.ok) {
+                    const data = await r.json();
+                    sbSegments = (data[0]?.segments || []).map(s => s.segment);
+                }
+            } finally {
+                sbReady = true;
+            }
+        }
+
+        function skipIfNeeded() {
+            if (!sbSegments) return;
+            const pos = audio.currentTime;
+            for (const seg of sbSegments) {
+                if (pos >= seg[0] && pos < seg[1]) {
+                    audio.currentTime = seg[1];
+                    break;
+                }
+            }
+        }
+
+        audio.addEventListener('timeupdate', skipIfNeeded);
+
+        audio.addEventListener('play', async () => {
+            if (!sbReady) {
+                audio.pause();
+                await fetchSponsorblock();
+                audio.play();
+            }
+        }, {once: true});
 
         fetch('/get_playback?item_id=' + itemId)
             .then(r => r.json())

--- a/www/index.php
+++ b/www/index.php
@@ -451,3 +451,37 @@ function set_playback(array $args): void
     $main->getState()->setPlaybackPosition(intval($args['item_id']), intval($args['position']));
 }
 
+#[Route('/get_sponsorblock', 'GET', true)]
+function get_sponsorblock(array $args): void
+{
+    global $main;
+
+    if (empty($args['item_id'])) {
+        $main->setResponseCode(404);
+        return;
+    }
+
+    $data = $main->getState()->getSponsorBlock(intval($args['item_id']));
+
+    if (empty($data)) {
+        $main->setResponseCode(204);
+        return;
+    }
+
+    header('Content-Type: application/json');
+    echo $data;
+}
+
+#[Route('/set_sponsorblock', 'POST', true)]
+function set_sponsorblock(array $args): void
+{
+    global $main;
+
+    if (empty($args['item_id']) || !isset($args['data'])) {
+        $main->setResponseCode(404);
+        return;
+    }
+
+    $main->getState()->setSponsorBlock(intval($args['item_id']), strval($args['data']));
+}
+


### PR DESCRIPTION
## Summary
- add sponsorblock column to item table
- extend DB migrations for sponsorblock
- expose routes for getting and setting sponsorblock data
- update State with sponsorblock helpers
- integrate sponsorblock JS on the item page and remove autoplay
- fix sponsorblock API request

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6850a265b3d0832299378655596f714c