### PR TITLE
Add configurable paging for feed page

### DIFF
--- a/conf/podsumer.conf
+++ b/conf/podsumer.conf
@@ -8,6 +8,7 @@ base_template = base
 state_file = state/podsumer.sqlite3
 sql_dir = sql
 per_item_art_download = 33
+items_per_page = 10
 ssl = false
 
 # File Storage Method

--- a/conf/test.conf
+++ b/conf/test.conf
@@ -8,6 +8,7 @@ base_template = base
 state_file = state/podsumer-test.sqlite3
 sql_dir = sql
 per_item_art_download = 33
+items_per_page = 10
 ssl = false
 
 media_dir = /opt/media

--- a/src/Brickner/Podsumer/State.php
+++ b/src/Brickner/Podsumer/State.php
@@ -205,6 +205,24 @@ class State
         return (false === $result) ? [] : $result;
     }
 
+    public function getFeedItemsPage(int $feed_id, int $limit, int $page = 1): array
+    {
+        $offset = ($page - 1) * $limit;
+        $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position FROM items JOIN feeds ON feeds.id = items.feed_id WHERE items.feed_id = :id ORDER BY items.published DESC LIMIT :limit OFFSET :offset';
+        $params = ['id' => $feed_id, 'limit' => $limit, 'offset' => $offset];
+        $result = $this->query($sql, $params);
+
+        return (false === $result) ? [] : $result;
+    }
+
+    public function countFeedItems(int $feed_id): int
+    {
+        $sql = 'SELECT COUNT(*) AS count FROM items WHERE feed_id = :id';
+        $result = $this->query($sql, ['id' => $feed_id]);
+
+        return intval($result[0]['count'] ?? 0);
+    }
+
     public function getFeedByHash(string $hash): array
     {
         $sql = 'SELECT id, name, last_update, url, description FROM feeds WHERE url_hash = :hash';

--- a/templates/feed.html.php
+++ b/templates/feed.html.php
@@ -32,4 +32,14 @@
         <?= substr(strip_tags($item['description']), 0, 360); ?>
     </div>
     <? endforeach ?>
+    <div class="py-4 font-bold">
+        <? if ($page > 1) { ?>
+            <a href="/feed?id=<?= $feed['id'] ?>&page=<?= $page - 1 ?>">Previous</a>
+        <? } ?>
+        <? if ($page < $page_count) { ?>
+            <? if ($page > 1) { ?>&nbsp;|&nbsp;<? } ?>
+            <a href="/feed?id=<?= $feed['id'] ?>&page=<?= $page + 1 ?>">Next</a>
+        <? } ?>
+        <span>&nbsp;&nbsp;Page <?= $page ?> of <?= $page_count ?></span>
+    </div>
 </div>

--- a/tests/Brickner/Podsumer/ConfigTest.php
+++ b/tests/Brickner/Podsumer/ConfigTest.php
@@ -22,6 +22,14 @@ final class ConfigTest extends TestCase
         $this->assertEquals($user, 'user');
     }
 
+    public function testGetItemsPerPage(): void
+    {
+        $config = new Config($this->root . DIRECTORY_SEPARATOR . 'conf/test.conf');
+        $per_page = $config->get('podsumer', 'items_per_page');
+
+        $this->assertEquals(10, $per_page);
+    }
+
     public function testGetGroup(): void
     {
         $config = new Config($this->root . DIRECTORY_SEPARATOR . 'conf/test.conf');

--- a/tests/Brickner/Podsumer/StateTest.php
+++ b/tests/Brickner/Podsumer/StateTest.php
@@ -84,6 +84,14 @@ final class StateTest extends TestCase
         $this->assertEquals(4, count($items));
     }
 
+    public function testGetFeedItemsPage()
+    {
+        $this->feed = new Feed(self::TEST_FEED_URL);
+        $this->state->addFeed($this->feed);
+        $items = $this->state->getFeedItemsPage(1, 2, 1);
+        $this->assertEquals(2, count($items));
+    }
+
     public function testGetFeedByHash()
     {
         $this->feed = new Feed(self::TEST_FEED_URL);

--- a/www/index.php
+++ b/www/index.php
@@ -83,9 +83,15 @@ function feed(array $args): void
 {
     global $main;
 
+    $page = isset($args['page']) ? max(1, intval($args['page'])) : 1;
+    $per_page = intval($main->getConf('podsumer', 'items_per_page')) ?: 10;
+    $feed_id = intval($args['id']);
+
     $vars = [
-        'feed' => $main->getState()->getFeed(intval($args['id'])),
-        'items' => $main->getState()->getFeedItems(intval($args['id']))
+        'feed' => $main->getState()->getFeed($feed_id),
+        'items' => $main->getState()->getFeedItemsPage($feed_id, $per_page, $page),
+        'page' => $page,
+        'page_count' => max(1, ceil($main->getState()->countFeedItems($feed_id) / $per_page))
     ];
 
     if (empty($vars['feed']) || empty($vars['items'])) {


### PR DESCRIPTION
## Summary
- paginate feed page results
- make items per page configurable via `items_per_page`
- expose pagination via template links
- test config and state pagination helpers

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6851733ce5408322a0566af6fb33764b