### PR TITLE
Add all episodes page

### DIFF
--- a/src/Brickner/Podsumer/State.php
+++ b/src/Brickner/Podsumer/State.php
@@ -205,7 +205,7 @@ class State
         return (false === $result) ? [] : $result;
     }
 
-
+        $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, items.image AS item_image, feeds.image AS feed_image, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position, feeds.name AS feed_name FROM items JOIN feeds ON feeds.id = items.feed_id ORDER BY items.published DESC';
     public function getAllItems(): array
     {
         $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position, feeds.name AS feed_name FROM items JOIN feeds ON feeds.id = items.feed_id ORDER BY items.published DESC';

--- a/src/Brickner/Podsumer/State.php
+++ b/src/Brickner/Podsumer/State.php
@@ -205,6 +205,15 @@ class State
         return (false === $result) ? [] : $result;
     }
 
+    public function getAllItems(): array
+    {
+        $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position, feeds.name AS feed_name FROM items JOIN feeds ON feeds.id = items.feed_id ORDER BY items.published DESC';
+
+        $result = $this->query($sql);
+
+        return (false === $result) ? [] : $result;
+    }
+
     public function getFeedByHash(string $hash): array
     {
         $sql = 'SELECT id, name, last_update, url, description FROM feeds WHERE url_hash = :hash';

--- a/src/Brickner/Podsumer/State.php
+++ b/src/Brickner/Podsumer/State.php
@@ -205,7 +205,6 @@ class State
         return (false === $result) ? [] : $result;
     }
 
-        $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, items.image AS item_image, feeds.image AS feed_image, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position, feeds.name AS feed_name FROM items JOIN feeds ON feeds.id = items.feed_id ORDER BY items.published DESC';
     public function getAllItems(): array
     {
         $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position, feeds.name AS feed_name FROM items JOIN feeds ON feeds.id = items.feed_id ORDER BY items.published DESC';

--- a/templates/base.html.php
+++ b/templates/base.html.php
@@ -11,6 +11,8 @@
         <h1 class="text-m font-black text-right">
             <a href="/">Feeds</a>
             &nbsp;|&nbsp;
+            <a href="/episodes">Episodes</a>
+            &nbsp;|&nbsp;
             <a href="/opml">OPML</a>
             &nbsp;|&nbsp;
            <?= round($db_size/1024/1024/1024, 2) ?> GB

--- a/templates/episodes.html.php
+++ b/templates/episodes.html.php
@@ -1,0 +1,32 @@
+<div class="container py-10">
+    <? if (empty($items)): ?>
+    <div class="container py-10 clear">
+        <h1 class="text-2xl">No Episodes</h1>
+    </div>
+    <? else: ?>
+    <? foreach ($items as $item): ?>
+    <div class="w-full clear-left py-8">
+        <a href="/item?item_id=<?= $item['id'] ?>">
+            <img src="/image?<?= 'item_id=' . $item['id'] ?: 'feed_id=' . $item['feed_id'] ?>" class="w-32 border-solid border-neutral-800 border inline float-left mr-4">
+        </a>
+        <a href="/item?item_id=<?= $item['id'] ?>" class="text-xl">
+            <?= $item['name'] ?>
+        </a>
+        <br>
+        <span class="text-neutral-500">
+            <?= $item['feed_name'] ?>
+            &nbsp;|&nbsp;
+            <?= round($item['size'] / 1024 / 1024, 1) ?>MB
+            &nbsp;|&nbsp;
+            <?= date('m/d/Y', strtotime($item['published'])); ?>
+            <? if (!empty($item['audio_file'])) { ?>
+            &nbsp;|&nbsp;
+            <a href="/delete_audio?item_id=<?= $item['id'] ?>">Delete Audio</a>
+            <? } ?>
+        </span>
+        <br>
+        <?= substr(strip_tags($item['description']), 0, 360); ?>
+    </div>
+    <? endforeach ?>
+    <? endif ?>
+</div>

--- a/templates/episodes.html.php
+++ b/templates/episodes.html.php
@@ -7,7 +7,7 @@
     <? foreach ($items as $item): ?>
     <div class="w-full clear-left py-8">
         <a href="/item?item_id=<?= $item['id'] ?>">
-            <img src="/image?<?= 'item_id=' . $item['id'] ?: 'feed_id=' . $item['feed_id'] ?>" class="w-32 border-solid border-neutral-800 border inline float-left mr-4">
+            <img src="/image?<?= !empty($item['item_image']) ? 'item_id=' . $item['id'] : 'feed_id=' . $item['feed_id'] ?>" class="w-32 border-solid border-neutral-800 border inline float-left mr-4">
         </a>
         <a href="/item?item_id=<?= $item['id'] ?>" class="text-xl">
             <?= $item['name'] ?>

--- a/tests/Brickner/Podsumer/StateTest.php
+++ b/tests/Brickner/Podsumer/StateTest.php
@@ -84,6 +84,14 @@ final class StateTest extends TestCase
         $this->assertEquals(4, count($items));
     }
 
+    public function testGetAllItems()
+    {
+        $this->feed = new Feed(self::TEST_FEED_URL);
+        $this->state->addFeed($this->feed);
+        $items = $this->state->getAllItems();
+        $this->assertEquals(4, count($items));
+    }
+
     public function testGetFeedByHash()
     {
         $this->feed = new Feed(self::TEST_FEED_URL);

--- a/www/index.php
+++ b/www/index.php
@@ -40,6 +40,18 @@ function home(array $args): void
     Template::render($main, 'home', $vars);
 }
 
+#[Route('/episodes', 'GET', true)]
+function episodes(array $args): void
+{
+    global $main;
+
+    $vars = [
+        'items' => $main->getState()->getAllItems()
+    ];
+
+    Template::render($main, 'episodes', $vars);
+}
+
 /**
  * Add new feed(s)
  * Path: /add


### PR DESCRIPTION
## Summary
- add global episodes route
- show link to episodes in base template
- list all episodes ordered by published date
- expose getAllItems() in State
- test State::getAllItems

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685173737bbc83228cd57bcf831728c2