### PR TITLE
Add pagination to episodes page

### DIFF
--- a/src/Brickner/Podsumer/State.php
+++ b/src/Brickner/Podsumer/State.php
@@ -214,6 +214,24 @@ class State
         return (false === $result) ? [] : $result;
      }
 
+    public function getAllItemsPage(int $limit, int $page = 1): array
+    {
+        $offset = ($page - 1) * $limit;
+        $sql = 'SELECT items.name, items.feed_id, items.id, items.guid, items.audio_url, items.audio_file, COALESCE(items.image, feeds.image) AS image, items.size, items.published, items.description, items.playback_position, feeds.name AS feed_name FROM items JOIN feeds ON feeds.id = items.feed_id ORDER BY items.published DESC LIMIT :limit OFFSET :offset';
+        $params = ['limit' => $limit, 'offset' => $offset];
+        $result = $this->query($sql, $params);
+
+        return (false === $result) ? [] : $result;
+    }
+
+    public function countAllItems(): int
+    {
+        $sql = 'SELECT COUNT(*) AS count FROM items';
+        $result = $this->query($sql);
+
+        return intval($result[0]['count'] ?? 0);
+    }
+
     public function getFeedItemsPage(int $feed_id, int $limit, int $page = 1): array
     {
         $offset = ($page - 1) * $limit;

--- a/templates/episodes.html.php
+++ b/templates/episodes.html.php
@@ -28,5 +28,15 @@
         <?= substr(strip_tags($item['description']), 0, 360); ?>
     </div>
     <? endforeach ?>
+    <div class="py-4 font-bold">
+        <? if ($page > 1) { ?>
+            <a href="/episodes?page=<?= $page - 1 ?>">Previous</a>
+        <? } ?>
+        <? if ($page < $page_count) { ?>
+            <? if ($page > 1) { ?>&nbsp;|&nbsp;<? } ?>
+            <a href="/episodes?page=<?= $page + 1 ?>">Next</a>
+        <? } ?>
+        <span>&nbsp;&nbsp;Page <?= $page ?> of <?= $page_count ?></span>
+    </div>
     <? endif ?>
 </div>

--- a/tests/Brickner/Podsumer/StateTest.php
+++ b/tests/Brickner/Podsumer/StateTest.php
@@ -100,6 +100,22 @@ final class StateTest extends TestCase
         $this->assertEquals(2, count($items));
     }
 
+    public function testGetAllItemsPage()
+    {
+        $this->feed = new Feed(self::TEST_FEED_URL);
+        $this->state->addFeed($this->feed);
+        $items = $this->state->getAllItemsPage(2, 1);
+        $this->assertEquals(2, count($items));
+    }
+
+    public function testCountAllItems()
+    {
+        $this->feed = new Feed(self::TEST_FEED_URL);
+        $this->state->addFeed($this->feed);
+        $count = $this->state->countAllItems();
+        $this->assertEquals(4, $count);
+    }
+
     public function testGetFeedByHash()
     {
         $this->feed = new Feed(self::TEST_FEED_URL);

--- a/www/index.php
+++ b/www/index.php
@@ -44,9 +44,13 @@ function home(array $args): void
 function episodes(array $args): void
 {
     global $main;
+    $page = isset($args['page']) ? max(1, intval($args['page'])) : 1;
+    $per_page = intval($main->getConf('podsumer', 'items_per_page')) ?: 10;
 
     $vars = [
-        'items' => $main->getState()->getAllItems()
+        'items' => $main->getState()->getAllItemsPage($per_page, $page),
+        'page' => $page,
+        'page_count' => max(1, ceil($main->getState()->countAllItems() / $per_page))
     ];
 
     Template::render($main, 'episodes', $vars);


### PR DESCRIPTION
## Summary
- add getAllItemsPage and countAllItems helpers
- implement paging on /episodes route
- show previous/next links on episodes template
- test new methods in StateTest

## Testing
- `composer test`
- `composer coverage`


------
https://chatgpt.com/codex/tasks/task_e_68517aab8b188322a092e4508d62efd0